### PR TITLE
refactor!: use descriptive strings for reset sequences

### DIFF
--- a/.yarn/versions/716ab411.yml
+++ b/.yarn/versions/716ab411.yml
@@ -1,0 +1,2 @@
+releases:
+  jest-serializer-ansi-escapes: major

--- a/src/__tests__/ansi-styles.test.js
+++ b/src/__tests__/ansi-styles.test.js
@@ -10,7 +10,7 @@ describe("supports ansi-styles", () => {
   test("supports style.red", async () => {
     expect(
       prettyFormat(`${ansiStyle.red.open} foo content ${ansiStyle.red.close}`)
-    ).toEqual('"<red> foo content </>"');
+    ).toEqual('"<red> foo content </color>"');
   });
 
   test("supports style.green", () => {
@@ -18,7 +18,7 @@ describe("supports ansi-styles", () => {
       prettyFormat(
         `${ansiStyle.green.open} foo content ${ansiStyle.green.close}`
       )
-    ).toEqual('"<green> foo content </>"');
+    ).toEqual('"<green> foo content </color>"');
   });
 
   test("supports style.reset", () => {

--- a/src/__tests__/color-and-style.test.js
+++ b/src/__tests__/color-and-style.test.js
@@ -6,27 +6,79 @@ function prettyFormat(text) {
 }
 
 describe("color and style sequences", () => {
-  test("supports reset (omitted 0)", async () => {
-    expect(prettyFormat("\u001b[31mSample text\u001b[m")).toEqual(
-      '"<red>Sample text</>"'
-    );
-  });
+  test.each([
+    { expected: '"</>"', sequence: "\u001b[m" }, // omitted zero
+    { expected: '"</>"', sequence: "\u001b[0m" },
 
-  test("supports red", async () => {
-    expect(prettyFormat("\u001b[31mSample text\u001b[0m")).toEqual(
-      '"<red>Sample text</>"'
-    );
+    { expected: '"<bold>"', sequence: "\u001b[1m" },
+    { expected: '"<dim>"', sequence: "\u001b[2m" },
+    { expected: '"<italic>"', sequence: "\u001b[3m" },
+    { expected: '"<underline>"', sequence: "\u001b[4m" },
+
+    { expected: '"<inverse>"', sequence: "\u001b[7m" },
+    { expected: '"<hidden>"', sequence: "\u001b[8m" },
+    { expected: '"<strikethrough>"', sequence: "\u001b[9m" },
+
+    { expected: '"</bold /dim>"', sequence: "\u001b[22m" },
+    { expected: '"</italic>"', sequence: "\u001b[23m" },
+    { expected: '"</underline>"', sequence: "\u001b[24m" },
+
+    { expected: '"</inverse>"', sequence: "\u001b[27m" },
+    { expected: '"</hidden>"', sequence: "\u001b[28m" },
+    { expected: '"</strikethrough>"', sequence: "\u001b[29m" },
+
+    { expected: '"<black>"', sequence: "\u001b[30m" },
+    { expected: '"<red>"', sequence: "\u001b[31m" },
+    { expected: '"<green>"', sequence: "\u001b[32m" },
+    { expected: '"<yellow>"', sequence: "\u001b[33m" },
+    { expected: '"<blue>"', sequence: "\u001b[34m" },
+    { expected: '"<magenta>"', sequence: "\u001b[35m" },
+    { expected: '"<cyan>"', sequence: "\u001b[36m" },
+    { expected: '"<white>"', sequence: "\u001b[37m" },
+
+    { expected: '"</color>"', sequence: "\u001b[39m" },
+
+    { expected: '"<backgroundBlack>"', sequence: "\u001b[40m" },
+    { expected: '"<backgroundRed>"', sequence: "\u001b[41m" },
+    { expected: '"<backgroundGreen>"', sequence: "\u001b[42m" },
+    { expected: '"<backgroundYellow>"', sequence: "\u001b[43m" },
+    { expected: '"<backgroundBlue>"', sequence: "\u001b[44m" },
+    { expected: '"<backgroundMagenta>"', sequence: "\u001b[45m" },
+    { expected: '"<backgroundCyan>"', sequence: "\u001b[46m" },
+    { expected: '"<backgroundWhite>"', sequence: "\u001b[47m" },
+
+    { expected: '"</background>"', sequence: "\u001b[49m" },
+
+    { expected: '"<overline>"', sequence: "\u001b[53m" },
+
+    { expected: '"</overline>"', sequence: "\u001b[55m" },
+
+    { expected: '"<gray>"', sequence: "\u001b[90m" },
+    { expected: '"<brightRed>"', sequence: "\u001b[91m" },
+    { expected: '"<brightGreen>"', sequence: "\u001b[92m" },
+    { expected: '"<brightYellow>"', sequence: "\u001b[93m" },
+    { expected: '"<brightBlue>"', sequence: "\u001b[94m" },
+    { expected: '"<brightMagenta>"', sequence: "\u001b[95m" },
+    { expected: '"<brightCyan>"', sequence: "\u001b[96m" },
+    { expected: '"<brightWhite>"', sequence: "\u001b[97m" },
+
+    { expected: '"<backgroundGray>"', sequence: "\u001b[100m" },
+    { expected: '"<backgroundBrightRed>"', sequence: "\u001b[101m" },
+    { expected: '"<backgroundBrightGreen>"', sequence: "\u001b[102m" },
+    { expected: '"<backgroundBrightYellow>"', sequence: "\u001b[103m" },
+    { expected: '"<backgroundBrightBlue>"', sequence: "\u001b[104m" },
+    { expected: '"<backgroundBrightMagenta>"', sequence: "\u001b[105m" },
+    { expected: '"<backgroundBrightCyan>"', sequence: "\u001b[106m" },
+    { expected: '"<backgroundBrightWhite>"', sequence: "\u001b[107m" },
+
+    { expected: '"<?>"', sequence: "\u001b[321m" }, // unrecognized sequence
+  ])("$sequence", ({ expected, sequence }) => {
+    expect(prettyFormat(sequence)).toEqual(expected);
   });
 
   test("supports red bold", async () => {
     expect(prettyFormat("\u001b[1;31mSample text\u001b[0m")).toEqual(
       '"<boldRed>Sample text</>"'
-    );
-  });
-
-  test("handles unrecognized sequence", () => {
-    expect(prettyFormat("\u001b[11mSample text\u001b[00m")).toEqual(
-      '"<?>Sample text<?>"'
     );
   });
 });

--- a/src/ansiEscapesSerializer.js
+++ b/src/ansiEscapesSerializer.js
@@ -2,20 +2,23 @@ const escape = "\u001b";
 
 const colorText = new Map([
   ["0", "/"],
+
   ["1", "bold"],
   ["2", "dim"],
   ["3", "italic"],
   ["4", "underline"],
+
   ["7", "inverse"],
   ["8", "hidden"],
   ["9", "strikethrough"],
 
-  ["22", "/"],
-  ["23", "/"],
-  ["24", "/"],
-  ["27", "/"],
-  ["28", "/"],
-  ["29", "/"],
+  ["22", "/bold /dim"],
+  ["23", "/italic"],
+  ["24", "/underline"],
+
+  ["27", "/inverse"],
+  ["28", "/hidden"],
+  ["29", "/strikethrough"],
 
   ["30", "black"],
   ["31", "red"],
@@ -25,7 +28,8 @@ const colorText = new Map([
   ["35", "magenta"],
   ["36", "cyan"],
   ["37", "white"],
-  ["39", "/"],
+
+  ["39", "/color"],
 
   ["40", ["background", "black"]],
   ["41", ["background", "red"]],
@@ -35,10 +39,12 @@ const colorText = new Map([
   ["45", ["background", "magenta"]],
   ["46", ["background", "cyan"]],
   ["47", ["background", "white"]],
-  ["49", "/"],
+
+  ["49", "/background"],
 
   ["53", "overline"],
-  ["55", "/"],
+
+  ["55", "/overline"],
 
   ["90", "gray"],
   ["91", ["bright", "red"]],


### PR DESCRIPTION
Currently `\u001b[0m` and `\u001b[39m` sequences are replaced with `</>` in snapshots. The sequences are different, so I think this should be reflected in snapshots as well. Hence, this PR introduces descriptive strings for all supported reset sequences instead of `</>`.

For example, `<dim><red>some</>text</>` becomes `<dim><red>some</color>text</>` (assuming that first reset is `\u001b[39m` and second is `\u001b[0m`).