### PR TITLE
fix!: use commas to separate color or style argument replacements

### DIFF
--- a/.yarn/versions/2ec562e1.yml
+++ b/.yarn/versions/2ec562e1.yml
@@ -1,0 +1,2 @@
+releases:
+  jest-serializer-ansi-escapes: major

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ would output this snapshot:
 
 ```js
 exports[`ansi escapes 1`] = `
-"<bold dim>Loading...</>
+"<bold, dim>Loading...</>
 <eraseLine>
 <moveCursorToColumn1>
-<italic green>Success!</>"
+<italic, green>Success!</>"
 `;
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ would output this snapshot:
 
 ```js
 exports[`ansi escapes 1`] = `
-"<boldDim>Loading...</>
+"<bold dim>Loading...</>
 <eraseLine>
 <moveCursorToColumn1>
-<italicGreen>Success!</>"
+<italic green>Success!</>"
 `;
 ```
 

--- a/example/__snapshots__/ansiEscapes.test.js.snap
+++ b/example/__snapshots__/ansiEscapes.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ansi escapes 1`] = `
-"<boldDim>Loading...</>
+"<bold dim>Loading...</>
 <eraseLine>
 <moveCursorToColumn1>
-<italicGreen>Success!</>"
+<italic green>Success!</>"
 `;

--- a/example/__snapshots__/ansiEscapes.test.js.snap
+++ b/example/__snapshots__/ansiEscapes.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ansi escapes 1`] = `
-"<bold dim>Loading...</>
+"<bold, dim>Loading...</>
 <eraseLine>
 <moveCursorToColumn1>
-<italic green>Success!</>"
+<italic, green>Success!</>"
 `;

--- a/src/__tests__/color-and-style.test.js
+++ b/src/__tests__/color-and-style.test.js
@@ -71,14 +71,12 @@ describe("color and style sequences", () => {
     { expected: '"<backgroundBrightCyan>"', sequence: "\u001b[106m" },
     { expected: '"<backgroundBrightWhite>"', sequence: "\u001b[107m" },
 
+    { expected: '"<bold red>"', sequence: "\u001b[1;31m" },
+    { expected: '"<bold inverse magenta>"', sequence: "\u001b[1;7;35m" },
+    { expected: '"</ dim>"', sequence: "\u001b[0;2m" },
+
     { expected: '"<?>"', sequence: "\u001b[321m" }, // unrecognized sequence
   ])("$sequence", ({ expected, sequence }) => {
     expect(prettyFormat(sequence)).toEqual(expected);
-  });
-
-  test("supports red bold", async () => {
-    expect(prettyFormat("\u001b[1;31mSample text\u001b[0m")).toEqual(
-      '"<boldRed>Sample text</>"'
-    );
   });
 });

--- a/src/__tests__/color-and-style.test.js
+++ b/src/__tests__/color-and-style.test.js
@@ -71,9 +71,9 @@ describe("color and style sequences", () => {
     { expected: '"<backgroundBrightCyan>"', sequence: "\u001b[106m" },
     { expected: '"<backgroundBrightWhite>"', sequence: "\u001b[107m" },
 
-    { expected: '"<bold red>"', sequence: "\u001b[1;31m" },
-    { expected: '"<bold inverse magenta>"', sequence: "\u001b[1;7;35m" },
-    { expected: '"</ dim>"', sequence: "\u001b[0;2m" },
+    { expected: '"<bold, red>"', sequence: "\u001b[1;31m" },
+    { expected: '"<bold, inverse, magenta>"', sequence: "\u001b[1;7;35m" },
+    { expected: '"</color, dim>"', sequence: "\u001b[39;2m" },
 
     { expected: '"<?>"', sequence: "\u001b[321m" }, // unrecognized sequence
   ])("$sequence", ({ expected, sequence }) => {

--- a/src/ansiEscapesSerializer.js
+++ b/src/ansiEscapesSerializer.js
@@ -31,14 +31,14 @@ const colorText = new Map([
 
   ["39", "/color"],
 
-  ["40", ["background", "black"]],
-  ["41", ["background", "red"]],
-  ["42", ["background", "green"]],
-  ["43", ["background", "yellow"]],
-  ["44", ["background", "blue"]],
-  ["45", ["background", "magenta"]],
-  ["46", ["background", "cyan"]],
-  ["47", ["background", "white"]],
+  ["40", "backgroundBlack"],
+  ["41", "backgroundRed"],
+  ["42", "backgroundGreen"],
+  ["43", "backgroundYellow"],
+  ["44", "backgroundBlue"],
+  ["45", "backgroundMagenta"],
+  ["46", "backgroundCyan"],
+  ["47", "backgroundWhite"],
 
   ["49", "/background"],
 
@@ -47,22 +47,22 @@ const colorText = new Map([
   ["55", "/overline"],
 
   ["90", "gray"],
-  ["91", ["bright", "red"]],
-  ["92", ["bright", "green"]],
-  ["93", ["bright", "yellow"]],
-  ["94", ["bright", "blue"]],
-  ["95", ["bright", "magenta"]],
-  ["96", ["bright", "cyan"]],
-  ["97", ["bright", "white"]],
+  ["91", "brightRed"],
+  ["92", "brightGreen"],
+  ["93", "brightYellow"],
+  ["94", "brightBlue"],
+  ["95", "brightMagenta"],
+  ["96", "brightCyan"],
+  ["97", "brightWhite"],
 
-  ["100", ["background", "gray"]],
-  ["101", ["background", "bright", "red"]],
-  ["102", ["background", "bright", "green"]],
-  ["103", ["background", "bright", "yellow"]],
-  ["104", ["background", "bright", "blue"]],
-  ["105", ["background", "bright", "magenta"]],
-  ["106", ["background", "bright", "cyan"]],
-  ["107", ["background", "bright", "white"]],
+  ["100", "backgroundGray"],
+  ["101", "backgroundBrightRed"],
+  ["102", "backgroundBrightGreen"],
+  ["103", "backgroundBrightYellow"],
+  ["104", "backgroundBrightBlue"],
+  ["105", "backgroundBrightMagenta"],
+  ["106", "backgroundBrightCyan"],
+  ["107", "backgroundBrightWhite"],
 ]);
 
 const commandText = new Map([
@@ -93,15 +93,9 @@ function colorOrStyleSequenceReplacer(sequenceText) {
     replacement.push(colorText.get(colorParameter) || "?");
   });
 
-  const replacementText = replacement.flat().map((segment, index) => {
-    if (index === 0) return segment;
+  const replacementText = replacement.flat();
 
-    return segment.replace(/^\w/, (firstCharacter) =>
-      firstCharacter.toUpperCase()
-    );
-  });
-
-  return `<${replacementText.join("")}>`;
+  return `<${replacementText.join(" ")}>`;
 }
 
 /**

--- a/src/ansiEscapesSerializer.js
+++ b/src/ansiEscapesSerializer.js
@@ -93,9 +93,7 @@ function colorOrStyleSequenceReplacer(sequenceText) {
     replacement.push(colorText.get(colorParameter) || "?");
   });
 
-  const replacementText = replacement.flat();
-
-  return `<${replacementText.join(" ")}>`;
+  return `<${replacement.join(", ")}>`;
 }
 
 /**


### PR DESCRIPTION
Currently `\u001b[1;31m` is replaced with `<boldRed>`. It was interesting idea, but it has two issues:

- it feels like the sequence had two separate arguments, I think that `<bold, red>` has better semantics;
- resets are allowed in the beginning of sequences, but `</colorRed>` looks plain wrong. Way better: `</color, red>`