### PR TITLE
fix: replace intensity reset with `</intensity>`

### DIFF
--- a/.yarn/versions/237afe6f.yml
+++ b/.yarn/versions/237afe6f.yml
@@ -1,0 +1,2 @@
+releases:
+  jest-serializer-ansi-escapes: patch

--- a/src/__tests__/color-and-style.test.js
+++ b/src/__tests__/color-and-style.test.js
@@ -19,7 +19,7 @@ describe("color and style sequences", () => {
     { expected: '"<hidden>"', sequence: "\u001b[8m" },
     { expected: '"<strikethrough>"', sequence: "\u001b[9m" },
 
-    { expected: '"</bold /dim>"', sequence: "\u001b[22m" },
+    { expected: '"</intensity>"', sequence: "\u001b[22m" },
     { expected: '"</italic>"', sequence: "\u001b[23m" },
     { expected: '"</underline>"', sequence: "\u001b[24m" },
 

--- a/src/ansiEscapesSerializer.js
+++ b/src/ansiEscapesSerializer.js
@@ -12,7 +12,7 @@ const colorText = new Map([
   ["8", "hidden"],
   ["9", "strikethrough"],
 
-  ["22", "/bold /dim"],
+  ["22", "/intensity"],
   ["23", "/italic"],
   ["24", "/underline"],
 


### PR DESCRIPTION
Fixing an issue introduces in https://github.com/mrazauskas/jest-serializer-ansi-escapes/pull/7.

`\u001b[22m` should be replaced with `</intensity>`. Just one string instead of double `</bold /dim>`.