### PR TITLE
chore!: drop support for Node.js 14 and 19

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -1,12 +1,7 @@
 {
   "name": "jest-serializer-ansi-escapes",
-  "description": "Jest snapshot serializer for ANSI escape sequences",
   "version": "2.0.1",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mrazauskas/jest-serializer-ansi-escapes.git"
-  },
+  "description": "Jest snapshot serializer for ANSI escape sequences",
   "keywords": [
     "ansi",
     "escape",
@@ -21,6 +16,11 @@
     "console",
     "terminal"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mrazauskas/jest-serializer-ansi-escapes.git"
+  },
+  "license": "MIT",
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "files": [
@@ -46,8 +46,8 @@
     "prettier": "3.0.3",
     "pretty-format": "29.7.0"
   },
+  "packageManager": "yarn@3.6.4",
   "engines": {
-    "node": ">=14"
-  },
-  "packageManager": "yarn@3.6.4"
+    "node": ">=16"
+  }
 }


### PR DESCRIPTION
Dropping support for Node.js 14 and 19. These versions are EOL (reference: the [release schedule](https://github.com/nodejs/release#release-schedule)). The upcoming Jest 30 is dropping these as well: https://github.com/jestjs/jest/pull/14460